### PR TITLE
fix: disable-host-node-id default value

### DIFF
--- a/1/debian-10/rootfs/opt/bitnami/scripts/consul/run.sh
+++ b/1/debian-10/rootfs/opt/bitnami/scripts/consul/run.sh
@@ -14,7 +14,7 @@ set -o pipefail
 eval "$(consul_env)"
 
 EXEC="${CONSUL_BASE_DIR}/bin/consul"
-flags=("agent" "-config-dir" "${CONSUL_CONF_DIR}" "-log-file" "${CONSUL_LOG_FILE}")
+flags=("agent" "-config-dir" "${CONSUL_CONF_DIR}" "-log-file" "${CONSUL_LOG_FILE}" "-disable-host-node-id" "true")
 
 if [[ "${CONSUL_AGENT_MODE}" = "server" ]]; then
     flags+=("-server")

--- a/1/debian-10/rootfs/opt/bitnami/scripts/consul/run.sh
+++ b/1/debian-10/rootfs/opt/bitnami/scripts/consul/run.sh
@@ -14,7 +14,7 @@ set -o pipefail
 eval "$(consul_env)"
 
 EXEC="${CONSUL_BASE_DIR}/bin/consul"
-flags=("agent" "-config-dir" "${CONSUL_CONF_DIR}" "-log-file" "${CONSUL_LOG_FILE}" "-disable-host-node-id" "true")
+flags=("agent" "-config-dir" "${CONSUL_CONF_DIR}" "-log-file" "${CONSUL_LOG_FILE}" "-disable-host-node-id=true")
 
 if [[ "${CONSUL_AGENT_MODE}" = "server" ]]; then
     flags+=("-server")


### PR DESCRIPTION
**Description of the change**

Changes the default value for https://www.consul.io/docs/agent/options.html#_disable_host_node_id to true, so that multiple pods can run on the same node, or start on a new node.

**Benefits**

No crashloopbackoffs in kubernetes.

**Possible drawbacks**

None

**Applicable issues**

https://github.com/bitnami/charts/issues/2315