### PR TITLE
Add `CONSUL_BIND_INTERFACE` environment variable

### DIFF
--- a/1/debian-10/Dockerfile
+++ b/1/debian-10/Dockerfile
@@ -8,9 +8,9 @@ ENV HOME="/" \
 
 COPY prebuildfs /
 # Install required system packages and dependencies
-RUN install_packages ca-certificates curl gzip procps tar
-RUN . /opt/bitnami/scripts/libcomponent.sh && component_unpack "render-template" "1.0.0-0" --checksum 63449e5ed4ece61d7bbeda0d173b68768d9fb444922b8ffa2e1042be20687142
-RUN . /opt/bitnami/scripts/libcomponent.sh && component_unpack "gosu" "1.12.0-0" --checksum 582d501eeb6b338a24f417fededbf14295903d6be55c52d66c52e616c81bcd8c
+RUN install_packages acl ca-certificates curl gzip procps tar iproute2
+RUN . /opt/bitnami/scripts/libcomponent.sh && component_unpack "render-template" "1.0.0-1" --checksum a94f94357aa06f3718db1550fa5f5188cd61383d66bf754eef49c58a18bf02cc
+RUN . /opt/bitnami/scripts/libcomponent.sh && component_unpack "gosu" "1.12.0-1" --checksum 51cfb1b7fd7b05b8abd1df0278c698103a9b1a4964bdacd87ca1d5c01631d59c
 RUN . /opt/bitnami/scripts/libcomponent.sh && component_unpack "consul" "1.8.0-0" --checksum e19d2c8de377f7e6f4b85237ab4000e780fd480e55b46a39131f65efdcd943ff
 RUN apt-get update && apt-get upgrade -y && \
     rm -r /var/lib/apt/lists /var/cache/apt/archives

--- a/1/debian-10/rootfs/opt/bitnami/scripts/consul/run.sh
+++ b/1/debian-10/rootfs/opt/bitnami/scripts/consul/run.sh
@@ -5,7 +5,6 @@
 set -o errexit
 set -o nounset
 set -o pipefail
-
 . /opt/bitnami/scripts/libconsul.sh
 . /opt/bitnami/scripts/libos.sh
 . /opt/bitnami/scripts/liblog.sh
@@ -18,6 +17,10 @@ flags=("agent" "-config-dir" "${CONSUL_CONF_DIR}" "-log-file" "${CONSUL_LOG_FILE
 
 if [[ "${CONSUL_AGENT_MODE}" = "server" ]]; then
     flags+=("-server")
+fi
+
+if [[ -n "${CONSUL_BIND_ADDR}" ]]; then
+    flags+=("-bind" "${CONSUL_BIND_ADDR}")
 fi
 
 info "** Starting Consul **"

--- a/1/debian-10/rootfs/opt/bitnami/scripts/libconsul.sh
+++ b/1/debian-10/rootfs/opt/bitnami/scripts/libconsul.sh
@@ -79,6 +79,8 @@ export CONSUL_SERF_LAN_ADDRESS="${CONSUL_SERF_LAN_ADDRESS:-0.0.0.0}"
 export CONSUL_SERF_LAN_PORT_NUMBER="${CONSUL_SERF_LAN_PORT_NUMBER:-8301}"
 export CONSUL_CLIENT_LAN_ADDRESS="${CONSUL_CLIENT_LAN_ADDRESS:-0.0.0.0}"
 export CONSUL_RETRY_JOIN_ADDRESS="${CONSUL_RETRY_JOIN_ADDRESS:-127.0.0.1}"
+export CONSUL_BIND_INTERFACE="${CONSUL_BIND_INTERFACE:-eth0}"
+export CONSUL_BIND_ADDR="$(get_bind_addr)"
 export CONSUL_ENABLE_UI="${CONSUL_ENABLE_UI:-true}"
 export CONSUL_BOOTSTRAP_EXPECT="${CONSUL_BOOTSTRAP_EXPECT:-1}"
 export CONSUL_RAFT_MULTIPLIER="${CONSUL_RAFT_MULTIPLIER:-1}"
@@ -234,5 +236,24 @@ get_consul_hostname() {
         echo "$CONSUL_NODE_NAME"
     else
         get_machine_ip
+    fi
+}
+
+########################
+# Determine the bind IP address for internal cluster communications from the given interface
+# Globals:
+#   CONSUL_BIND_INTERFACE
+# Arguments:
+#   None
+# Returns:
+#   The ip address of the given interface or "" (will be bound to all addresses)
+########################
+get_bind_addr() {
+    if [[ -n "$CONSUL_BIND_INTERFACE" ]]; then
+        CONSUL_BIND_ADDRESS=$(ip -o -4 addr list "$CONSUL_BIND_INTERFACE" | head -n1 | awk '{print $4}' | cut -d/ -f1)
+        echo "$CONSUL_BIND_ADDRESS"
+        if [[ -z "$CONSUL_BIND_ADDRESS" ]]; then
+            echo ""
+        fi
     fi
 }

--- a/README.md
+++ b/README.md
@@ -307,6 +307,7 @@ When you start the HashiCorp Consul image, you can adjust the configuration of t
 - `CONSUL_DOMAIN`: HashiCorp Consul domain name. Default: **consul**.
 - `CONSUL_DATACENTER"`: The datacenter in which the agent is running. Default: **dc1**.
 - `CONSUL_RETRY_JOIN_ADDRESS`: "Address of another agent to join upon starting up. Default: **127.0.0.1**
+- `CONSUL_BIND_INTERFACE`: "The interface that will be bound to for internal cluster communications. Default: **eth0**
 
 ### Specifying Environment Variables using Docker Compose
 


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

**Description of the change**

<!-- Describe the scope of your change - i.e. what the change does. -->
Add `CONSUL_BIND_INTERFACE` environment variable to fix a `Cannot to configure with 'bind' and/or 'advertise'` error on the machine with multiple ipv4 interfaces as seen in #3.

**Benefits**

<!-- What benefits will be realized by the code change? -->

No crash loop with multiple interfaces.

**Possible drawbacks**

<!-- Describe any known limitations with your change -->

Should be installed an `iproute2` package when dockerizing.

**Applicable issues**

<!-- Enter any applicable Issues here (You can reference an issue using #) -->

https://github.com/bitnami/bitnami-docker-consul/issues/3

**Additional information**

None

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here.-->
