### PR TITLE
support passing CONSUL_GOSSIP_ENCRYPTION_KEY already base64 encoded

### DIFF
--- a/1/debian-10/rootfs/opt/bitnami/scripts/libconsul.sh
+++ b/1/debian-10/rootfs/opt/bitnami/scripts/libconsul.sh
@@ -196,11 +196,6 @@ consul_configure_encryption() {
 
         if [[ -z ${CONSUL_GOSSIP_ENCRYPTION_KEY} ]]; then
             CONSUL_GOSSIP_ENCRYPTION_KEY=$("${CONSUL_BASE_DIR}/bin/consul" "keygen" )
-        elif ( base64 -d <<< "${CONSUL_GOSSIP_ENCRYPTION_KEY}" >/dev/null 2>&1 ); then
-            # The encryption key passed is already base64 , use it as it is
-            info "Using CONSUL_GOSSIP_ENCRYPTION_KEY as is"
-        else
-            CONSUL_GOSSIP_ENCRYPTION_KEY=$(base64 <<< "${CONSUL_GOSSIP_ENCRYPTION_KEY}")
         fi
 
         render-template "${CONSUL_ENCRYPT_TEMPLATE_FILE}" > "${CONSUL_ENCRYPT_FILE}"

--- a/1/debian-10/rootfs/opt/bitnami/scripts/libconsul.sh
+++ b/1/debian-10/rootfs/opt/bitnami/scripts/libconsul.sh
@@ -196,6 +196,9 @@ consul_configure_encryption() {
 
         if [[ -z ${CONSUL_GOSSIP_ENCRYPTION_KEY} ]]; then
             CONSUL_GOSSIP_ENCRYPTION_KEY=$("${CONSUL_BASE_DIR}/bin/consul" "keygen" )
+        elif ( base64 -d <<< "${CONSUL_GOSSIP_ENCRYPTION_KEY}" >/dev/null 2>&1 ); then
+            # The encryption key passed is already base64 , use it as it is
+            info "Using CONSUL_GOSSIP_ENCRYPTION_KEY as is"
         else
             CONSUL_GOSSIP_ENCRYPTION_KEY=$(base64 <<< "${CONSUL_GOSSIP_ENCRYPTION_KEY}")
         fi

--- a/README.md
+++ b/README.md
@@ -301,7 +301,7 @@ When you start the HashiCorp Consul image, you can adjust the configuration of t
 - `CONSUL_RAFT_MULTIPLIER`: An integer multiplier used by HashiCorp Consul servers to scale key Raft timing parameters. Default: **1**.
 - `CONSUL_LOCAL_CONFIG`: Custom user configuration that will be added as a file in the config dir.
 - `CONSUL_GOSSIP_ENCRYPTION`: Enable Gossip encryption. Default: **no**.
-- `CONSUL_GOSSIP_ENCRYPTION_KEY`: Gossip private simmetric key.
+- `CONSUL_GOSSIP_ENCRYPTION_KEY`: Gossip private simmetric key. This is expected to be a `base64` encoded string
 - `CONSUL_GOSSIP_ENCRYPTION_KEY_FILE`: File containing the gossip private simmetric key. If both `CONSUL_GOSSIP_ENCRYPTION_KEY` and `CONSUL_GOSSIP_ENCRYPTION_KEY_FILE` are provided, consul will use the `CONSUL_GOSSIP_ENCRYPTION_KEY_FILE`.
 - `CONSUL_DISABLE_KEYRING_FILE`: If set, the keyring will not be persisted to a file. Valid vaules: true, false. Default: **false**.
 - `CONSUL_ENABLE_UI`: Enable web user interface. Valid values: true, false. Default: **true**.
@@ -377,7 +377,7 @@ $ docker run -d -e CONSUL_LOCAL_CONFIG='{
 Check the [Persisting your data](# Persisting your application) section to add custom volumes to the HashiCorp Consul container
 
 ## Configuring the Gossip encryption key
-Specifies the secret key to use for encryption of HashiCorp Consul network traffic. This key must be 16-bytes that are Base64-encoded. The easiest way to create an encryption key is to use `consul keygen`
+Specifies the secret key to use for encryption of HashiCorp Consul network traffic. This key must be 32-bytes that are Base64-encoded. The easiest way to create an encryption key is to use `consul keygen`
 
 ```console
 $ docker run --name consul bitnami/consul:latest consul keygen


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

**Description of the change**

Support passing an `already base64 encoded CONSUL_GOSSIP_ENCRYPTION_KEY` , as is the output of `consul keygen`

**Benefits**

The output of `consul keygen` is already base64 encoded so to make it easy to pass without encoding or escaping problems , see https://github.com/bitnami/bitnami-docker-consul/issues/10#issuecomment-720371798


**Possible drawbacks**
this change is backward compatible, it will change the logic by checking if the KEY Passed is already base64 encoded , if is not it will behave as before

**Applicable issues**

https://github.com/bitnami/bitnami-docker-consul/issues/10


**Additional information**
