### PR TITLE
Fix environment name CONSUL_BIND_ADDRESS -> CONSUL_BIND_ADDR

### DIFF
--- a/1/debian-10/rootfs/opt/bitnami/scripts/libconsul.sh
+++ b/1/debian-10/rootfs/opt/bitnami/scripts/libconsul.sh
@@ -134,10 +134,10 @@ consul_initialize() {
         export CONSUL_NODE_NAME="$machine_ip"
     fi
 
-    if [[ -n "$CONSUL_BIND_INTERFACE" ]] && [[ -z "${CONSUL_BIND_ADDRESS:-}" ]]; then
-        info "CONSUL_BIND_INTERFACE was set to $CONSUL_BIND_INTERFACE and CONSUL_BIND_ADDRESS was not set, obtaining bind address"
+    if [[ -n "$CONSUL_BIND_INTERFACE" ]] && [[ -z "${CONSUL_BIND_ADDR:-}" ]]; then
+        info "CONSUL_BIND_INTERFACE was set to $CONSUL_BIND_INTERFACE and CONSUL_BIND_ADDR was not set, obtaining bind address"
         local -r bind_address=$(ip -o -4 addr list "$CONSUL_BIND_INTERFACE" | head -n1 | awk '{print $4}' | cut -d/ -f1)
-        export CONSUL_BIND_ADDRESS="$bind_address"
+        export CONSUL_BIND_ADDR="$bind_address"
     fi
 
     if is_dir_empty "${CONSUL_DATA_DIR}"; then


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

**Description of the change**
This PR helps to fix the error of not getting the correct IP when the CONSUL_BIND_INTERFACE variable exists

<!-- Describe the scope of your change - i.e. what the change does. -->

**Benefits**
Automatically get IP and save to CONSUL_BIND_ADDR when variable CONSUL_BIND_INTERFACE exists
<!-- What benefits will be realized by the code change? -->

**Possible drawbacks**
No
<!-- Describe any known limitations with your change -->

**Applicable issues**
No
<!-- Enter any applicable Issues here (You can reference an issue using #) -->

**Additional information**
https://raw.githubusercontent.com/bitnami/bitnami-docker-consul/master/1/debian-10/rootfs/opt/bitnami/scripts/consul-env.sh
<!-- If there's anything else that's important and relevant to your pull
request, mention that information here.-->
